### PR TITLE
Remove user-agent and other values from header

### DIFF
--- a/mercury_parser.py
+++ b/mercury_parser.py
@@ -59,11 +59,11 @@ class ParserAPI(object):
 
     def parse(self, url):
         url = '{0}{1}'.format(MERCURY_API, url)
-        headers = {'x-api-key': self.api_key}
-
+        headers={'User-Agent': None,
+        'Connection': None,
+        'Accept-Encoding': None,
+        'x-api-key': self.api_key,
+        'Content-Type': 'application/json'}
         r = self._session.get(url, headers=headers)
         p = ParsedArticle.from_dict(r.json(), parser=self)
         return p
-
-
-


### PR DESCRIPTION
The Mercury Parser API blocks some user agents, including python-requests. Removing the user-agent key allows the request to go through and return content.

I removed default connection and accept-encoding values as well as they are not required by the Mercury Parser API.